### PR TITLE
Set stronger cipher for TLS

### DIFF
--- a/sslserver/management/commands/runsslserver.py
+++ b/sslserver/management/commands/runsslserver.py
@@ -51,8 +51,8 @@ class SecureHTTPServer(ThreadedWSGIServer):
         self.socket = ssl.wrap_socket(self.socket, certfile=certificate,
                                       keyfile=key, server_side=True,
                                       ssl_version=_ssl_version,
-                                      cert_reqs=ssl.CERT_NONE)
-
+                                      cert_reqs=ssl.CERT_NONE,
+                                      ciphers='AES256-GCM-SHA384')
 
 class WSGIRequestHandler(WSGIRequestHandler):
     def get_environ(self):


### PR DESCRIPTION
From Python 3.10, "Python should no longer enable TLS 1.1 by default and require strong TLS ciphers with forward secrecy."

https://bugs.python.org/issue43998